### PR TITLE
Fix requirements.txt missing error using MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
While working on another project I discovered that when packaging the `requirements.txt` doesn't get included, and this will cause an error when trying to install from for example PyPI.

This will include a `MANIFEST.in` that specifies that the `requirements.txt` should be included when packaging.
